### PR TITLE
Fix/36/sticky image empty

### DIFF
--- a/src/landingPage/ToolsSection.tsx
+++ b/src/landingPage/ToolsSection.tsx
@@ -8,10 +8,10 @@ import { placeholderTexts } from 'placeholders/ToolsSectionImage';
 
 const ToolsSection = (props: any) => {
   const [realVisibility, setRealVisibility] = useState<boolean[]>(
-    [true, false, false, false, false],
+    [false, false, false, false, false],
   );
   const [transitionVisibility, setTransitionVisibility] = useState<boolean[]>(
-    [true, false, false, false, false],
+    [false, false, false, false, false],
   );
 
   useEffect(() => {
@@ -41,10 +41,11 @@ const ToolsSection = (props: any) => {
                   onChange={(isVisible: boolean) => {
                     const newRealVisibility = [...realVisibility];
                     newRealVisibility[index] = isVisible;
-                    console.log(newRealVisibility);
                     setRealVisibility(newRealVisibility);
                   }}
-                  // partialVisibility={true}
+                  intervalDelay={10}
+                  intervalCheck={true}
+                  scrollCheck={true}
                 >
                   <li>
                     <h3 className={styles.gradient_color}>{content.title}</h3>

--- a/src/landingPage/ToolsSection.tsx
+++ b/src/landingPage/ToolsSection.tsx
@@ -8,10 +8,10 @@ import { placeholderTexts } from 'placeholders/ToolsSectionImage';
 
 const ToolsSection = (props: any) => {
   const [realVisibility, setRealVisibility] = useState<boolean[]>(
-    TOOL_SECTION_CONTENT.map(() => false),
+    [true, false, false, false, false],
   );
   const [transitionVisibility, setTransitionVisibility] = useState<boolean[]>(
-    TOOL_SECTION_CONTENT.map(() => false),
+    [true, false, false, false, false],
   );
 
   useEffect(() => {

--- a/src/landingPage/ToolsSection.tsx
+++ b/src/landingPage/ToolsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './ToolsSection.module.scss';
 import GhostBlock from 'common/GhostBlock';
 import { TOOL_SECTION_CONTENT } from '../content/ToolSectionText';
@@ -7,12 +7,24 @@ import { Transition } from 'react-transition-group';
 import { placeholderTexts } from 'placeholders/ToolsSectionImage';
 
 const ToolsSection = (props: any) => {
-  const [sectionVisibility, setSectionVisibility] = useState<boolean[]>(
-    TOOL_SECTION_CONTENT.map(() => true),
+  const [realVisibility, setRealVisibility] = useState<boolean[]>(
+    TOOL_SECTION_CONTENT.map(() => false),
+  );
+  const [transitionVisibility, setTransitionVisibility] = useState<boolean[]>(
+    TOOL_SECTION_CONTENT.map(() => false),
   );
 
+  useEffect(() => {
+    const firstVisibleIndex = realVisibility.indexOf(true);
+    if (firstVisibleIndex !== -1) {
+      const newVisbility = TOOL_SECTION_CONTENT.map(() => false);
+      newVisbility[firstVisibleIndex] = true;
+      setTransitionVisibility(newVisbility);
+    }
+  }, [realVisibility]);
+
   return (
-    <section className={styles.container} id='tools'>
+    <section className={styles.container} id="tools">
       <div className={styles.subcontainer}>
         <div>
           <h1 className={`${styles.titleBold} ${styles.gradient_color}`}>
@@ -27,10 +39,12 @@ const ToolsSection = (props: any) => {
               return (
                 <VisibilitySensor
                   onChange={(isVisible: boolean) => {
-                    const newSectionVisibility = [...sectionVisibility];
-                    newSectionVisibility[index] = isVisible;
-                    setSectionVisibility(newSectionVisibility);
+                    const newRealVisibility = [...realVisibility];
+                    newRealVisibility[index] = isVisible;
+                    console.log(newRealVisibility);
+                    setRealVisibility(newRealVisibility);
                   }}
+                  // partialVisibility={true}
                 >
                   <li>
                     <h3 className={styles.gradient_color}>{content.title}</h3>
@@ -45,7 +59,7 @@ const ToolsSection = (props: any) => {
             <div className={styles.stickyBox}>
               <GhostBlock>
                 {placeholderTexts.map((text, index) => (
-                  <Transition in={sectionVisibility[index]} timeout={500}>
+                  <Transition in={transitionVisibility[index]} timeout={500}>
                     {(state) => (
                       <p
                         style={{


### PR DESCRIPTION
# Description
Performance boost, fast check rate so the scroll and update image in tool section will hopefully be more responsive

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
